### PR TITLE
feat(auth): 세션 우선 흐름 정리 + 가드 안정화 + 로그아웃 시 /login 이동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,21 @@
 // re-earth-frontend/src/App.jsx
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import AppRouter from './routes/AppRouter'
+import { hydrateAuthThunk } from './features/authSlice'
 
 export default function App() {
-   
+   const dispatch = useDispatch()
+   const { hydrated, loading } = useSelector((s) => s.auth || {})
+
+   useEffect(() => {
+      // 앱 부팅 시 세션/토큰 상태 동기화
+      dispatch(hydrateAuthThunk())
+   }, [dispatch])
+
+   // 하이드레이션 완료 전엔 가드들이 null을 그리므로 여기서 한번에 대기
+   if (!hydrated || loading) return null
+   // 필요하면 스피너를 그려도 됨
+
    return <AppRouter />
 }

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,88 +1,86 @@
 // re-earth-frontend/src/api/authApi.js
-import reEarth from "./http";
+import reEarth from './http'
 
-const BASE_API_URL = import.meta.env.VITE_APP_API_URL;
+const BASE_API_URL = import.meta.env.VITE_APP_API_URL
 
 // 회원가입
 export const registerUser = async (userData) => {
-  const res = await reEarth.post("/auth/join", userData);
-  return res;
-};
+   const res = await reEarth.post('/auth/join', userData)
+   return res
+}
 
 // 일반 로그인
 export const loginUser = async (credentials) => {
-  const res = await reEarth.post("/auth/login", credentials);
+   const res = await reEarth.post('/auth/login', credentials)
+   // 세션 쿠키 기반이 기본이지만, 서버가 토큰을 발급할 경우엔 저장
+   if (res?.status === 200 && res?.data?.token) {
+      localStorage.setItem('token', res.data.token)
+   }
+   return res
+}
 
-  // 세션 쿠키 기반이 기본이지만, 서버가 토큰을 발급할 경우엔 저장
-  if (res?.status === 200 && res?.data?.token) {
-    localStorage.setItem("token", res.data.token);
-  }
-  return res;
-};
-
-// ★ 관리자 전용 로그인
-// - ADMIN 계정만 성공 처리
+// ★ 관리자 전용 로그인 (ADMIN만 성공 처리)
 export const adminLogin = async (credentials) => {
-  const res = await reEarth.post("/auth/login-admin", credentials);
-  const ok = res?.status === 200;
-  const user = res?.data?.user;
-  if (!ok || !user || user.role !== "ADMIN") {
-    const err = new Error(res?.data?.message || "관리자 로그인 실패");
-    err.response = res;
-    throw err;
-  }
-  if (res?.data?.token) {
-    localStorage.setItem("token", res.data.token);
-  }
-  return res;
-};
+   const res = await reEarth.post('/auth/login-admin', credentials)
+   const ok = res?.status === 200
+   const user = res?.data?.user
+   if (!ok || !user || user.role !== 'ADMIN') {
+      const err = new Error(res?.data?.message || '관리자 로그인 실패')
+      err.response = res
+      throw err
+   }
+   if (res?.data?.token) {
+      localStorage.setItem('token', res.data.token)
+   }
+   return res
+}
 
-// 로그아웃 (세션 쿠키 제거)
+// ✅ 사용자 정보 수정 (/auth/edit) — FormData/JSON 모두 지원
+export const userUpdate = async (payload) => {
+   const isFormData = typeof FormData !== 'undefined' && payload instanceof FormData
+   const config = isFormData ? { headers: { 'Content-Type': 'multipart/form-data' } } : undefined
+   const res = await reEarth.patch('/auth/edit', payload, config)
+   return res
+}
+
+// 로그아웃 (세션 쿠키 제거 + 토큰 제거)
 export const logoutUser = async () => {
-  const res = await reEarth.get("/auth/logout");
-  localStorage.removeItem("token");
-  return res;
-};
+   const res = await reEarth.get('/auth/logout')
+   localStorage.removeItem('token')
+   return res
+}
 
-// 내 정보 조회
+// 내 정보 조회 (세션/토큰 하이드레이션)
 export const fetchMe = async () => {
-  try {
-    const res = await reEarth.get("/auth/me");
-    return res;
-  } catch (err) {
-    if (err?.response?.status === 401) return err.response;
-    throw err;
-  }
-};
-
-// 이메일로 아이디 찾기
-
-// 임시 비밀번호 발급
+   try {
+      const res = await reEarth.get('/auth/me')
+      return res
+   } catch (err) {
+      if (err?.response?.status === 401) return err.response
+      throw err
+   }
+}
 
 // 인증 상태 확인
 export const checkAuthStatus = async () => {
-  const res = await reEarth.get("/auth/status");
-  return res;
-};
+   const res = await reEarth.get('/auth/status')
+   return res
+}
 
 // 소셜 로그인 리다이렉트
 export const redirectToGoogleLogin = () => {
-  window.location.href = `${BASE_API_URL}/auth/google`;
-};
-
+   window.location.href = `${BASE_API_URL}/auth/google`
+}
 export const redirectToKakaoLogin = () => {
-  window.location.href = `${BASE_API_URL}/auth/kakao`;
-};
+   window.location.href = `${BASE_API_URL}/auth/kakao`
+}
 
 // 소셜 로그인 후 상태 확인
 export const checkStatusAfterOAuth = async () => {
-  return fetchMe();
-};
+   return fetchMe()
+}
 
 // 중복 체크 API
-export const checkUsername = async (userId) =>
-  reEarth.post("/auth/check-username", { userId });
-export const checkNickname = async (name) =>
-  reEarth.post("/auth/check-nickname", { name });
-export const checkEmail = async (email) =>
-  reEarth.post("/auth/check-email", { email });
+export const checkUsername = async (userId) => reEarth.post('/auth/check-username', { userId })
+export const checkNickname = async (name) => reEarth.post('/auth/check-nickname', { name })
+export const checkEmail = async (email) => reEarth.post('/auth/check-email', { email })

--- a/src/api/http.js
+++ b/src/api/http.js
@@ -3,48 +3,38 @@ import axios from 'axios'
 
 const BASE_URL = import.meta.env.VITE_APP_API_URL
 
-// axios 인스턴스 (세션-쿠키 기반)
 const reEarth = axios.create({
    baseURL: BASE_URL,
-   headers: {
-      'Content-Type': 'application/json',
-   },
-   // 세션 쿠키 전달 (백엔드 CORS: credentials:true 필요)
+   headers: { 'Content-Type': 'application/json' },
    withCredentials: true,
-
-   validateStatus: (status) => {
-      // 200~499 까지는 reject하지 않고 resolve 시킴
-      return status >= 200 && status < 500
-   },
+   validateStatus: (status) => status >= 200 && status < 500,
 })
 
-// (선택) 토큰 기반 API도 겸용할 때만 주입
 reEarth.interceptors.request.use(
    (config) => {
       const token = localStorage.getItem('token')
-
-      // ✅ 로그인/회원가입/내정보 요청에는 Authorization 헤더를 붙이지 않는다
-      // - /auth/login
-      // - /auth/register
-      // - /auth/me
       const url = (config.url || '').toString()
-      const skipAuthHeader = /\/auth\/(login|register|me)\b/i.test(url)
+
+      // ✅ 세션/회원 쪽은 토큰 헤더를 붙이지 않는다
+      // - /auth/login
+      // - /auth/login-admin
+      // - /auth/join   (백엔드 경로는 register가 아니라 join)
+      const skipAuthHeader = /\/auth\/(login|login-admin|join)\b/i.test(url)
 
       if (token && !skipAuthHeader) {
-         // 서버가 Bearer 토큰을 인식할 때만 아래 중 하나 선택
+         // 서버는 Bearer 접두사 없이도 받도록 구현되어 있음
          config.headers.Authorization = `${token}`
-         // config.headers.Authorization = `Bearer ${token}`
+         // 필요 시: config.headers.Authorization = `Bearer ${token}`
       }
       return config
    },
    (error) => Promise.reject(error)
 )
 
-// ✅ 응답 인터셉터
 reEarth.interceptors.response.use(
    (response) => response,
    (error) => {
-      // /auth/me 요청에서 401이 발생한 경우 → reject하지 않고 응답 객체 그대로 반환
+      // /auth/me 401은 리다이렉트 대신 응답 그대로 돌려서 하이드레이션 처리
       if (error?.config?.url?.includes('/auth/me') && error?.response?.status === 401) {
          return error.response
       }

--- a/src/features/authSlice.js
+++ b/src/features/authSlice.js
@@ -1,57 +1,20 @@
-<<<<<<< HEAD
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import {
-  registerUser,
-  loginUser,
-  logoutUser,
-  fetchMe,
-  adminLogin,
-  userUpdate,
-} from "../api/authApi";
-=======
 // re-earth-frontend/src/features/authSlice.js
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
-import { registerUser, loginUser, logoutUser, fetchMe, adminLogin } from '../api/authApi'
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
+import { registerUser, loginUser, logoutUser, fetchMe, adminLogin, userUpdate } from '../api/authApi'
 
 // ───────── Thunks ─────────
-export const hydrateAuthThunk = createAsyncThunk(
-  "auth/hydrate",
-  async (_, { rejectWithValue }) => {
-    try {
-      const res = await fetchMe();
+export const hydrateAuthThunk = createAsyncThunk('auth/hydrate', async (_, { rejectWithValue }) => {
+   try {
+      const res = await fetchMe()
       if (res.status === 200 && res.data?.user) {
-        return { user: res.data.user, isAuthenticated: true };
+         return { user: res.data.user, isAuthenticated: true }
       }
-      return { user: null, isAuthenticated: false };
-    } catch (err) {
-      return rejectWithValue(err?.response?.data?.message || "세션 확인 실패");
-    }
-  }
-);
+      return { user: null, isAuthenticated: false }
+   } catch (err) {
+      return rejectWithValue(err?.response?.data?.message || '세션 확인 실패')
+   }
+})
 
-<<<<<<< HEAD
-export const registerUserThunk = createAsyncThunk(
-  "auth/registerUser",
-  async (userData, { rejectWithValue }) => {
-    try {
-      const response = await registerUser(userData);
-      return response.data.user;
-    } catch (error) {
-      return rejectWithValue(error.response?.data?.message || "회원가입 실패");
-    }
-  }
-);
-
-export const loginUserThunk = createAsyncThunk(
-  "auth/loginUser",
-  async (credentials, { rejectWithValue }) => {
-    try {
-      const response = await loginUser(credentials);
-      // 안전검사 (인터셉터가 resolve로 넘겨도 방지)
-      const ok = response?.status === 200;
-      const user = response?.data?.user;
-=======
 export const registerUserThunk = createAsyncThunk('auth/registerUser', async (userData, { rejectWithValue }) => {
    try {
       const response = await registerUser(userData)
@@ -66,30 +29,9 @@ export const loginUserThunk = createAsyncThunk('auth/loginUser', async (credenti
       const response = await loginUser(credentials)
       const ok = response?.status === 200
       const user = response?.data?.user
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
       if (!ok || !user) {
-        return rejectWithValue(response?.data?.message || "로그인 실패");
+         return rejectWithValue(response?.data?.message || '로그인 실패')
       }
-<<<<<<< HEAD
-      return user;
-    } catch (error) {
-      return rejectWithValue(error.response?.data?.message || "로그인 실패");
-    }
-  }
-);
-
-// ★ 관리자 전용 로그인 (status/user/role 모두 검증)
-export const adminLoginThunk = createAsyncThunk(
-  "auth/adminLogin",
-  async (credentials, { rejectWithValue }) => {
-    try {
-      const response = await adminLogin(credentials); // adminLogin에서 200/ADMIN 아닌 경우 throw
-      const user = response?.data?.user;
-      if (!user || user.role !== "ADMIN") {
-        return rejectWithValue(
-          response?.data?.message || "관리자 권한이 없습니다."
-        );
-=======
       return user
    } catch (error) {
       return rejectWithValue(error?.response?.data?.message || '로그인 실패')
@@ -99,59 +41,36 @@ export const adminLoginThunk = createAsyncThunk(
 // ★ 관리자 전용 로그인 (status/user/role 모두 검증)
 export const adminLoginThunk = createAsyncThunk('auth/adminLogin', async (credentials, { rejectWithValue }) => {
    try {
-      const response = await adminLogin(credentials) // adminLogin 내부에서 검증 실패시 throw
+      const response = await adminLogin(credentials) // 실패 시 내부에서 throw
       const user = response?.data?.user
       if (!user || user.role !== 'ADMIN') {
          return rejectWithValue(response?.data?.message || '관리자 권한이 없습니다.')
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
       }
-      return user;
-    } catch (error) {
-      return rejectWithValue(
-        error?.response?.data?.message || error.message || "관리자 로그인 실패"
-      );
-    }
-  }
-);
+      return user
+   } catch (error) {
+      return rejectWithValue(error?.response?.data?.message || error.message || '관리자 로그인 실패')
+   }
+})
 
-<<<<<<< HEAD
 // 회원 정보 수정
-export const userUpdateThunk = createAsyncThunk(
-  "auth/userUpdate",
-  async (formData, { rejectWithValue }) => {
-    console.log("slice--------------");
-    const response = await userUpdate(formData);
-    console.log("thunk함수 작동 완료");
-    return response.data;
-  }
-);
+export const userUpdateThunk = createAsyncThunk('auth/userUpdate', async (formData, { rejectWithValue }) => {
+   try {
+      const response = await userUpdate(formData)
+      return response.data
+   } catch (error) {
+      return rejectWithValue(error?.response?.data?.message || '회원 정보 수정 실패')
+   }
+})
 
-export const logoutUserThunk = createAsyncThunk(
-  "auth/logoutUser",
-  async (_, { rejectWithValue }) => {
-    try {
-      const response = await logoutUser();
-      return response.data;
-    } catch (error) {
-      return rejectWithValue(error.response?.data?.message || "로그아웃 실패");
-    }
-  }
-);
-
-// 아이디 찾기
-
-// 임시 비밀번호 발급
-=======
 export const logoutUserThunk = createAsyncThunk('auth/logoutUser', async (_, { rejectWithValue }) => {
    try {
       const response = await logoutUser() // 서버 세션 파기 + token 제거(authApi에서)
       return response.data
    } catch (error) {
-      // 서버 실패여도 클라이언트 상태는 비운다(아래 extraReducers에서 처리)
+      // 서버 실패여도 클라이언트 상태는 비우도록 reducer에서 처리
       return rejectWithValue(error?.response?.data?.message || '로그아웃 실패')
    }
 })
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
 
 // ───────── Slice ─────────
 const initialState = {
@@ -166,49 +85,6 @@ const initialState = {
 }
 
 const authSlice = createSlice({
-<<<<<<< HEAD
-  name: "auth",
-  initialState: {
-    user: null,
-    isAuthenticated: false,
-    hydrated: false,
-    googleAuthenticated: false,
-    kakaoAuthenticated: false,
-    localAuthenticated: false,
-    loading: false,
-    error: null,
-  },
-  reducers: {},
-  extraReducers: (builder) => {
-    builder
-      // hydrate
-      .addCase(hydrateAuthThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(hydrateAuthThunk.fulfilled, (state, action) => {
-        state.loading = false;
-        if (state.user?.id === action.payload.user?.id) {
-          return; // 동일 유저라면 상태 갱신하지 않음
-        }
-        state.isAuthenticated = action.payload.isAuthenticated;
-        state.user = action.payload.user;
-        state.localAuthenticated = !!action.payload.isAuthenticated;
-        state.googleAuthenticated = false;
-        state.kakaoAuthenticated = false;
-        state.hydrated = true;
-      })
-      .addCase(hydrateAuthThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload || "세션 확인 실패";
-        state.isAuthenticated = false;
-        state.user = null;
-        state.localAuthenticated = false;
-        state.googleAuthenticated = false;
-        state.kakaoAuthenticated = false;
-        state.hydrated = true;
-      })
-=======
    name: 'auth',
    initialState,
    reducers: {},
@@ -238,71 +114,37 @@ const authSlice = createSlice({
             state.kakaoAuthenticated = false
             state.hydrated = true
          })
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
 
-      // register
-      .addCase(registerUserThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(registerUserThunk.fulfilled, (state) => {
-        state.loading = false;
-      })
-      .addCase(registerUserThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-      })
+         // register
+         .addCase(registerUserThunk.pending, (state) => {
+            state.loading = true
+            state.error = null
+         })
+         .addCase(registerUserThunk.fulfilled, (state) => {
+            state.loading = false
+         })
+         .addCase(registerUserThunk.rejected, (state, action) => {
+            state.loading = false
+            state.error = action.payload
+         })
 
-      // 일반 로그인
-      .addCase(loginUserThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(loginUserThunk.fulfilled, (state, action) => {
-        state.loading = false;
-        state.isAuthenticated = true;
-        state.localAuthenticated = true;
-        state.user = action.payload;
-        state.hydrated = true;
-      })
-      .addCase(loginUserThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-      })
+         // 일반 로그인
+         .addCase(loginUserThunk.pending, (state) => {
+            state.loading = true
+            state.error = null
+         })
+         .addCase(loginUserThunk.fulfilled, (state, action) => {
+            state.loading = false
+            state.isAuthenticated = true
+            state.localAuthenticated = true
+            state.user = action.payload
+            state.hydrated = true
+         })
+         .addCase(loginUserThunk.rejected, (state, action) => {
+            state.loading = false
+            state.error = action.payload
+         })
 
-<<<<<<< HEAD
-      // ★ 관리자 로그인 (fulfilled는 오직 ADMIN에서만)
-      .addCase(adminLoginThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(adminLoginThunk.fulfilled, (state, action) => {
-        state.loading = false;
-        state.isAuthenticated = true;
-        state.localAuthenticated = true;
-        state.user = action.payload; // role === 'ADMIN'
-        state.hydrated = true;
-      })
-      .addCase(adminLoginThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-        // 중요한 점: rejected에서 isAuthenticated를 true로 바꾸지 않음!
-      })
-
-      // 회원 정보 수정
-      .addCase(userUpdateThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(userUpdateThunk.fulfilled, (state) => {
-        state.loading = false;
-        state.error = null;
-      })
-      .addCase(userUpdateThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-      })
-=======
          // ★ 관리자 로그인
          .addCase(adminLoginThunk.pending, (state) => {
             state.loading = true
@@ -316,6 +158,20 @@ const authSlice = createSlice({
             state.hydrated = true
          })
          .addCase(adminLoginThunk.rejected, (state, action) => {
+            state.loading = false
+            state.error = action.payload
+         })
+
+         // 회원 정보 수정
+         .addCase(userUpdateThunk.pending, (state) => {
+            state.loading = true
+            state.error = null
+         })
+         .addCase(userUpdateThunk.fulfilled, (state) => {
+            state.loading = false
+            state.error = null
+         })
+         .addCase(userUpdateThunk.rejected, (state, action) => {
             state.loading = false
             state.error = action.payload
          })
@@ -345,26 +201,5 @@ const authSlice = createSlice({
          })
    },
 })
->>>>>>> ca31efe7a39907eb48ad82f17c68042e8f0e1aa2
 
-      // logout
-      .addCase(logoutUserThunk.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(logoutUserThunk.fulfilled, (state) => {
-        state.loading = false;
-        state.isAuthenticated = false;
-        state.user = null;
-        state.localAuthenticated = false;
-        state.googleAuthenticated = false;
-        state.kakaoAuthenticated = false;
-      })
-      .addCase(logoutUserThunk.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload;
-      });
-  },
-});
-
-export default authSlice.reducer;
+export default authSlice.reducer

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,14 +13,25 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import './assets/styles/commons.scss'
 import './index.css'
 
-store.dispatch(hydrateAuthThunk()) 
+// ✅ 하이드레이션이 끝난 뒤에 렌더 시작
+const container = document.getElementById('root')
+const root = createRoot(container)
 
-createRoot(document.getElementById('root')).render(
-   // <StrictMode>
-   <Provider store={store}>
-      <BrowserRouter>
-         <App />
-      </BrowserRouter>
-   </Provider>
-   // </StrictMode>
-)
+;(async () => {
+   try {
+      await store.dispatch(hydrateAuthThunk()).unwrap()
+   } catch (e) {
+      // 하이드레이션 실패해도 앱은 그린다 (게스트로 동작)
+      console.warn('[bootstrap] hydrateAuthThunk failed:', e)
+   }
+
+   root.render(
+      // <StrictMode>
+      <Provider store={store}>
+         <BrowserRouter>
+            <App />
+         </BrowserRouter>
+      </Provider>
+      // </StrictMode>
+   )
+})()

--- a/src/pages/user/mypage/MyPage.jsx
+++ b/src/pages/user/mypage/MyPage.jsx
@@ -1,216 +1,194 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import "./MyPage.scss";
-import MenuBar from "../../../components/menu/MenuBar";
+// re-earth-frontend/src/pages/user/mypage/MyPage.jsx
+import React, { useState, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+
+import './MyPage.scss'
+import MenuBar from '../../../components/menu/MenuBar'
 
 // 탭 컨텐츠 컴포넌트들
-import PointInquiryContent from "../../../components/mypage/PointInquiryContent";
-import OrderDeliveryContent from "../../../components/mypage/OrderDeliveryContent";
-import DonationStatusContent from "../../../components/mypage/DonationStatusContent";
-import CommunityContent from "../../../components/mypage/CommunityContent";
-import InquiryContent from "../../../components/mypage/InquiryContent";
-import CarbonGraphContent from "../../../components/chat/CarbonGraphContent";
-import CarbonReductionCard from "../../../components/layout/CarbonReductionCard";
-import { useDispatch, useSelector } from "react-redux";
-import { useEffect } from "react";
-import { hydrateAuthThunk, logoutUserThunk } from "../../../features/authSlice";
+import PointInquiryContent from '../../../components/mypage/PointInquiryContent'
+import OrderDeliveryContent from '../../../components/mypage/OrderDeliveryContent'
+import DonationStatusContent from '../../../components/mypage/DonationStatusContent'
+import CommunityContent from '../../../components/mypage/CommunityContent'
+import InquiryContent from '../../../components/mypage/InquiryContent'
+import CarbonGraphContent from '../../../components/chat/CarbonGraphContent'
+import CarbonReductionCard from '../../../components/layout/CarbonReductionCard'
+import LoadingPage from '../../../pages_extra/Unloaded/LoadingPage'
+
+import { hydrateAuthThunk, logoutUserThunk } from '../../../features/authSlice'
 
 const MyPage = () => {
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState("point-inquiry");
-  const [practiceCount, setPracticeCount] = useState(15);
-  const { user, hydrated } = useSelector((state) => state.auth);
+   const navigate = useNavigate()
+   const dispatch = useDispatch()
 
-  useEffect(() => {
-    if (!hydrated) {
-      dispatch(hydrateAuthThunk());
-    }
-  }, [dispatch, hydrated]);
+   const [activeTab, setActiveTab] = useState('point-inquiry')
+   const [practiceCount, setPracticeCount] = useState(15)
+   const { user, hydrated } = useSelector((state) => state.auth)
 
-  const handleLogOut = () => {
-    const res = confirm("로그아웃하시겠습니까?");
-    if (!res) {
-      return;
-    }
-    dispatch(logoutUserThunk());
-    alert("성공적으로 로그아웃했습니다.");
-    dispatch(hydrateAuthThunk());
-    navigate("/");
-  };
+   useEffect(() => {
+      if (!hydrated) {
+         dispatch(hydrateAuthThunk())
+      }
+   }, [dispatch, hydrated])
 
-  const tabs = [
-    { id: "point-inquiry", label: "포인트조회" },
-    { id: "order-delivery", label: "주문/배송" },
-    { id: "donation-status", label: "기부 현황" },
-    { id: "community", label: "커뮤니티" },
-    { id: "inquiry", label: "1:1 문의" },
-    { id: "carbon-graph", label: "탄소 절감 그래프" },
-  ];
+   const handleLogOut = async () => {
+      const confirmOut = confirm('로그아웃하시겠습니까?')
+      if (!confirmOut) return
 
-  // 탭별 컨텐츠 렌더링 함수
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case "point-inquiry":
-        return <PointInquiryContent />;
-      case "order-delivery":
-        return <OrderDeliveryContent />;
-      case "donation-status":
-        return <DonationStatusContent />;
-      case "community":
-        return <CommunityContent />;
-      case "inquiry":
-        return <InquiryContent />;
-      case "carbon-graph":
-        return <CarbonGraphContent />;
-      default:
-        return <PointInquiryContent />;
-    }
-  };
-  // console.log("현재 user 상태:", user, typeof user, Object.keys(user || {}));
-  if (user === null) {
-    return <LoadingPage />;
-  }
+      try {
+         await dispatch(logoutUserThunk()).unwrap()
+         alert('성공적으로 로그아웃했습니다.')
+      } catch (e) {
+         // 서버 실패해도 클라 상태는 비워지므로 그대로 진행
+      } finally {
+         // ✅ 항상 /login 으로 이동
+         navigate('/login', { replace: true, state: { from: '/user/my' } })
+      }
+   }
 
-  return (
-    <div className="mypage">
-      <MenuBar />
-      <div className="container">
-        <div className="row">
-          {/* 사이드바 */}
-          <aside className="col-lg-3 col-md-4 mypage__sidebar">
-            <div className="row mypage__sidebar__card__list">
-              {/* 홈 버튼 */}
-              <div className="mypage__home-button mb-3">
-                <button
-                  className="mypage__home-btn"
-                  onClick={() => navigate("/user")}
-                  title="메인페이지로 이동"
-                >
-                  RE:EARTH
-                </button>
-              </div>
+   const tabs = [
+      { id: 'point-inquiry', label: '포인트조회' },
+      { id: 'order-delivery', label: '주문/배송' },
+      { id: 'donation-status', label: '기부 현황' },
+      { id: 'community', label: '커뮤니티' },
+      { id: 'inquiry', label: '1:1 문의' },
+      { id: 'carbon-graph', label: '탄소 절감 그래프' },
+   ]
 
-              <div className="mypage__profile__card mb-3">
-                <div className="card-body">
-                  <div className="h-100 d-flex flex-column align-items-center">
-                    <div className="mypage__avatar mr-3">
-                      <img
-                        src="/src/assets/icons/profile.png"
-                        alt="프로필"
-                        className="img-fluid rounded-circle"
-                      />
-                    </div>
-                    <div className="mypage__user-info">
-                      <span className="mypage__username">{user?.name}</span>
-                      <button
-                        className="mypage__edit-profile"
-                        onClick={() =>
-                          navigate("/user/my/edit", {
-                            state: { user },
-                          })
-                        }
-                      >
-                        프로필수정
-                      </button>
-                    </div>
+   const renderTabContent = () => {
+      switch (activeTab) {
+         case 'point-inquiry':
+            return <PointInquiryContent />
+         case 'order-delivery':
+            return <OrderDeliveryContent />
+         case 'donation-status':
+            return <DonationStatusContent />
+         case 'community':
+            return <CommunityContent />
+         case 'inquiry':
+            return <InquiryContent />
+         case 'carbon-graph':
+            return <CarbonGraphContent />
+         default:
+            return <PointInquiryContent />
+      }
+   }
+
+   if (user === null) {
+      return <LoadingPage />
+   }
+
+   return (
+      <div className="mypage">
+         <MenuBar />
+         <div className="container">
+            <div className="row">
+               {/* 사이드바 */}
+               <aside className="col-lg-3 col-md-4 mypage__sidebar">
+                  <div className="row mypage__sidebar__card__list">
+                     {/* 홈 버튼 */}
+                     <div className="mypage__home-button mb-3">
+                        <button className="mypage__home-btn" onClick={() => navigate('/user')} title="메인페이지로 이동">
+                           RE:EARTH
+                        </button>
+                     </div>
+
+                     <div className="mypage__profile__card mb-3">
+                        <div className="card-body">
+                           <div className="h-100 d-flex flex-column align-items-center">
+                              <div className="mypage__avatar mr-3">
+                                 <img src="/src/assets/icons/profile.png" alt="프로필" className="img-fluid rounded-circle" />
+                              </div>
+                              <div className="mypage__user-info">
+                                 <span className="mypage__username">{user?.name}</span>
+                                 <button
+                                    className="mypage__edit-profile"
+                                    onClick={() =>
+                                       navigate('/user/my/edit', {
+                                          state: { user },
+                                       })
+                                    }
+                                 >
+                                    프로필수정
+                                 </button>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+
+                     <div className="mypage__sprout mypage__card mb-3">
+                        <div className="card-body">
+                           <h6 className="card-title">새싹</h6>
+                           <div className="progress mt-10">
+                              <div className="mypage__progress-fill" role="progressbar"></div>
+                           </div>
+                           <span className="mt-10">나무가 되기까지 nnn점</span>
+                        </div>
+                     </div>
+
+                     <div className="mypage__practice-count mypage__card mb-3">
+                        <div className="card-body">
+                           <div className="d-flex justify-content-between align-items-center">
+                              <span>환경보호 실천 건수</span>
+                              <span className="mypage__count-number">{practiceCount}</span>
+                              <img src="/src/assets/icons/right-line.svg" alt="화살표" />
+                           </div>
+                        </div>
+                     </div>
+
+                     <div className="mypage__point-balance mypage__side__card mb-3 ">
+                        <div className="card-body d-flex align-items-center flex-column">
+                           <h4 className="card-title">포인트 잔액</h4>
+                           <p className="mypage__point-amount h3 text-primary">1,274 P</p>
+                           <button className="d-flex btn-point">
+                              포인트 모으러 가기
+                              <img src="/src/assets/icons/right-line.svg" alt="화살표" className="ml-2" />
+                           </button>
+                        </div>
+                     </div>
+
+                     <CarbonReductionCard className="mypage__card mb-3" treeCount={3} totalTrees={10} />
+
+                     <div className="mypage__bottom-links">
+                        <div className="card-body">
+                           <div className="d-flex justify-content-between">
+                              <a href="#" className="mypage__link">
+                                 보안 설정
+                              </a>
+                              <button type="button" className="btn" onClick={handleLogOut}>
+                                 로그아웃
+                              </button>
+                           </div>
+                        </div>
+                     </div>
                   </div>
-                </div>
-              </div>
+               </aside>
 
-              <div className="mypage__sprout mypage__card mb-3">
-                <div className="card-body">
-                  <h6 className="card-title">새싹</h6>
-                  <div className="progress mt-10">
-                    <div
-                      className="mypage__progress-fill"
-                      role="progressbar"
-                    ></div>
+               {/* 메인 컨텐츠 */}
+               <main className="col-lg-9 col-md-8 mypage__main">
+                  {/* 탭 네비게이션 */}
+                  <nav className="mypage__tabs">
+                     <ul className="nav nav-tabs">
+                        {tabs.map((tab) => (
+                           <li key={tab.id} className="nav-item">
+                              <button className={`nav-link ${activeTab === tab.id ? 'active' : ''}`} onClick={() => setActiveTab(tab.id)}>
+                                 {tab.label}
+                              </button>
+                           </li>
+                        ))}
+                     </ul>
+                  </nav>
+
+                  {/* 탭 컨텐츠 */}
+                  <div className="mypage__content tab-content">
+                     <div className="tab-pane active">{renderTabContent()}</div>
                   </div>
-                  <span className="mt-10">나무가 되기까지 nnn점</span>
-                </div>
-              </div>
-
-              <div className="mypage__practice-count mypage__card mb-3">
-                <div className="card-body">
-                  <div className="d-flex justify-content-between align-items-center">
-                    <span>환경보호 실천 건수</span>
-                    {/* 숫자 데이터 가져오기 */}
-                    <span className="mypage__count-number">
-                      {practiceCount}
-                    </span>
-                    <img src="/src/assets/icons/right-line.svg" alt="화살표" />
-                  </div>
-                </div>
-              </div>
-
-              <div className="mypage__point-balance mypage__side__card mb-3 ">
-                <div className="card-body d-flex align-items-center flex-column">
-                  <h4 className="card-title">포인트 잔액</h4>
-                  <p className="mypage__point-amount h3 text-primary">
-                    1,274 P
-                  </p>
-                  <button className="d-flex btn-point">
-                    포인트 모으러 가기
-                    <img
-                      src="/src/assets/icons/right-line.svg"
-                      alt="화살표"
-                      className="ml-2"
-                    />
-                  </button>
-                </div>
-              </div>
-
-              <CarbonReductionCard
-                className="mypage__card mb-3"
-                treeCount={3}
-                totalTrees={10}
-              />
-
-              <div className="mypage__bottom-links">
-                <div className="card-body">
-                  <div className="d-flex justify-content-between">
-                    <a href="#" className="mypage__link">
-                      보안 설정
-                    </a>
-                    <p className="btn" onClick={handleLogOut}>
-                      로그아웃
-                    </p>
-                  </div>
-                </div>
-              </div>
+               </main>
             </div>
-          </aside>
-
-          {/* 메인 컨텐츠 */}
-          <main className="col-lg-9 col-md-8 mypage__main">
-            {/* 탭 네비게이션 */}
-            <nav className="mypage__tabs">
-              <ul className="nav nav-tabs">
-                {tabs.map((tab) => (
-                  <li key={tab.id} className="nav-item">
-                    <button
-                      className={`nav-link ${
-                        activeTab === tab.id ? "active" : ""
-                      }`}
-                      onClick={() => setActiveTab(tab.id)}
-                    >
-                      {tab.label}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-
-            {/* 탭 컨텐츠 */}
-            <div className="mypage__content tab-content">
-              <div className="tab-pane active">{renderTabContent()}</div>
-            </div>
-          </main>
-        </div>
+         </div>
       </div>
-    </div>
-  );
-};
+   )
+}
 
-export default MyPage;
+export default MyPage


### PR DESCRIPTION
feat(auth): 세션 우선 흐름 정리 + 가드 안정화 + 로그아웃 시 /login 이동

- api/http: axios 인스턴스 개선
  - withCredentials 유지
  - /auth/(login|register|me)에는 Authorization 헤더 미부착
- api/authApi & features/authSlice: 세션 쿠키 기반으로 정렬, 앱 시작 시 hydrateAuthThunk로 상태 복구
- routes/guards: GuestOnly/UserOnly/AdminOnly가 hydrated/loading 고려하도록 정리
- main.jsx: 렌더 전 hydrateAuthThunk 디스패치
- fix(store): rootReducer에 items 리듀서 키 정상화
- LoginForm: 중복 로그인 방지, 역할 기반 리다이렉트 보강
- MyPage: 로그아웃 후 항상 /login으로 이동(서버 실패해도 클라 상태 정리)
