### PR TITLE
[feat](qna): 마이페이지 문의 목록/상세 연동 및 관리자 1:1 문의 관리 연결

### DIFF
--- a/src/components/mypage/InquiryContent.jsx
+++ b/src/components/mypage/InquiryContent.jsx
@@ -1,111 +1,225 @@
-import React, { useState } from 'react';
-import TableContent from '../layout/TableContent';
+// re-earth-frontend/src/components/mypage/InquiryContent.jsx
+import { useEffect, useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import TableContent from '../layout/TableContent'
+import { fetchMyQnasThunk, fetchQnaDetailThunk } from '../../features/qnaSlice'
 
-const InquiryContent = () => {
-  const [activeSubTab, setActiveSubTab] = useState('integrated');
-  const [currentPage, setCurrentPage] = useState(1);
-  
-  const subTabs = [
-    { id: 'integrated', label: '통합문의' },
-    { id: 'pending', label: '답변대기' },
-    { id: 'completed', label: '답변완료' },
-    { id: 'new', label: '새 문의작성' }
-  ];
+const PER_PAGE = 10
 
-  const columns = ['날짜', '제목', '상태'];
-  
-  const integratedData = [
-    {
-      '날짜': '2025-01-15',
-      '제목': '게시글 1 예시 텍스트입니다.',
-      '상태': '답변완료'
-    },
-    {
-      '날짜': '2025-01-14',
-      '제목': '게시글 2 예시 텍스트입니다.',
-      '상태': '확인 중'
-    },
-    {
-      '날짜': '2025-01-13',
-      '제목': '포인트 적립 문의',
-      '상태': '답변완료'
-    }
-  ];
+const statusToKo = (s) => {
+   if (!s) return '-'
+   const up = String(s).toUpperCase()
+   if (up === 'OPEN') return '답변대기'
+   if (up === 'ANSWERED') return '답변완료'
+   if (up === 'CLOSED') return '종료'
+   return up
+}
 
-  const pendingData = [
-    {
-      '날짜': '2025-01-14',
-      '제목': '게시글 2 예시 텍스트입니다.',
-      '상태': '확인 중'
-    },
-    {
-      '날짜': '2025-01-12',
-      '제목': '배송 관련 문의',
-      '상태': '처리중'
-    }
-  ];
+export default function InquiryContent() {
+   const dispatch = useDispatch()
+   const navigate = useNavigate()
 
-  const completedData = [
-    {
-      '날짜': '2025-01-15',
-      '제목': '게시글 1 예시 텍스트입니다.',
-      '상태': '답변완료'
-    },
-    {
-      '날짜': '2025-01-13',
-      '제목': '포인트 적립 문의',
-      '상태': '답변완료'
-    },
-    {
-      '날짜': '2025-01-11',
-      '제목': '계정 관련 문의',
-      '상태': '답변완료'
-    }
-  ];
+   const { list = [], detail, loading, error } = useSelector((s) => s.qna || {})
+   const [activeSubTab, setActiveSubTab] = useState('integrated')
+   const [currentPage, setCurrentPage] = useState(1)
 
-  const newData = [
-    {
-      '날짜': '-',
-      '제목': '새로운 문의를 작성해보세요',
-      '상태': '작성하기'
-    }
-  ];
+   // 최초 로드 시 내 문의 목록 가져오기
+   useEffect(() => {
+      dispatch(fetchMyQnasThunk())
+   }, [dispatch])
 
-  const getCurrentData = () => {
-    switch (activeSubTab) {
-      case 'integrated': return integratedData;
-      case 'pending': return pendingData;
-      case 'completed': return completedData;
-      case 'new': return newData;
-      default: return integratedData;
-    }
-  };
+   // "새 문의작성" 탭 선택 시 바로 작성 페이지로 이동
+   useEffect(() => {
+      if (activeSubTab === 'new') {
+         navigate('/inquiry/new')
+      }
+   }, [activeSubTab, navigate])
 
-  const handleDetailsClick = (row) => {
-    console.log('문의 상세:', row);
-    // 상세 모달 또는 페이지로 이동
-  };
+   // 탭별 필터링된 데이터
+   const filtered = useMemo(() => {
+      const byDateDesc = [...(list || [])].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      switch (activeSubTab) {
+         case 'pending':
+            return byDateDesc.filter((q) => String(q.status).toUpperCase() === 'OPEN')
+         case 'completed':
+            return byDateDesc.filter((q) => ['ANSWERED', 'CLOSED'].includes(String(q.status).toUpperCase()))
+         case 'integrated':
+         default:
+            return byDateDesc
+      }
+   }, [list, activeSubTab])
 
-  const handlePageChange = (page) => {
-    if (page >= 1 && page <= 3) {
-      setCurrentPage(page);
-    }
-  };
+   // 페이지네이션
+   const totalPages = Math.max(1, Math.ceil((filtered.length || 0) / PER_PAGE))
+   const pageData = useMemo(() => {
+      const start = (currentPage - 1) * PER_PAGE
+      return filtered.slice(start, start + PER_PAGE)
+   }, [filtered, currentPage])
 
-  return (
-    <TableContent
-      title="1:1 문의"
-      subTabs={subTabs}
-      activeSubTab={activeSubTab}
-      onSubTabChange={setActiveSubTab}
-      columns={columns}
-      data={getCurrentData()}
-      onDetailsClick={handleDetailsClick}
-      currentPage={currentPage}
-      totalPages={3}
-      onPageChange={handlePageChange}
-    />
-  );
-};
+   // TableContent에 맞는 데이터 형태로 매핑
+   const columns = ['날짜', '제목', '상태']
+   const data = pageData.map((q) => ({
+      id: q.id,
+      원본: q,
+      날짜: q.createdAt ? new Date(q.createdAt).toISOString().slice(0, 10) : '-',
+      제목: q.title || '(제목 없음)',
+      상태: statusToKo(q.status),
+   }))
 
-export default InquiryContent;
+   const subTabs = [
+      { id: 'integrated', label: '통합문의' },
+      { id: 'pending', label: '답변대기' },
+      { id: 'completed', label: '답변완료' },
+      { id: 'new', label: '새 문의작성' },
+   ]
+
+   // 상세 보기 클릭 시 서버에서 최신 상세 가져와서 모달 노출
+   const [showModal, setShowModal] = useState(false)
+   const [selectedId, setSelectedId] = useState(null)
+
+   const handleDetailsClick = async (row) => {
+      if (!row || !row.id) return
+      setSelectedId(row.id)
+      try {
+         await dispatch(fetchQnaDetailThunk(row.id)).unwrap()
+         setShowModal(true)
+      } catch (e) {
+         alert('문의 상세 조회에 실패했습니다.')
+      }
+   }
+
+   const closeModal = () => {
+      setShowModal(false)
+      setSelectedId(null)
+   }
+
+   const handlePageChange = (page) => {
+      if (page >= 1 && page <= totalPages) setCurrentPage(page)
+   }
+
+   return (
+      <>
+         <TableContent
+            title="1:1 문의"
+            subTabs={subTabs}
+            activeSubTab={activeSubTab}
+            onSubTabChange={(tabId) => {
+               setActiveSubTab(tabId)
+               setCurrentPage(1)
+            }}
+            columns={columns}
+            data={data}
+            onDetailsClick={handleDetailsClick}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+         />
+
+         {/* 상태 표시 */}
+         {loading && <div className="mt-2">불러오는 중…</div>}
+         {error && <div className="mt-2 text-danger">에러: {String(error?.message || error)}</div>}
+         {!loading && !error && filtered.length === 0 && activeSubTab !== 'new' && <div className="mt-2">표시할 문의가 없습니다.</div>}
+
+         {/* 간단 상세 모달 */}
+         {showModal && detail && selectedId === detail?.id && (
+            <div
+               role="dialog"
+               aria-modal="true"
+               className="qna-modal-backdrop"
+               onClick={closeModal}
+               style={{
+                  position: 'fixed',
+                  inset: 0,
+                  background: 'rgba(0,0,0,0.4)',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  zIndex: 1000,
+               }}
+            >
+               <div
+                  className="qna-modal"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                     width: 'min(720px, 92vw)',
+                     maxHeight: '80vh',
+                     overflowY: 'auto',
+                     background: '#fff',
+                     borderRadius: 12,
+                     padding: 20,
+                     boxShadow: '0 10px 30px rgba(0,0,0,0.2)',
+                  }}
+               >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+                     <h5 style={{ margin: 0 }}>{detail.title || '문의 상세'}</h5>
+                     <button className="btn btn-sm btn-outline-secondary" onClick={closeModal}>
+                        닫기
+                     </button>
+                  </div>
+
+                  <div style={{ fontSize: 14, color: '#666', marginTop: 8 }}>
+                     <span>작성일: {detail.createdAt ? new Date(detail.createdAt).toLocaleString() : '-'}</span>
+                     <span style={{ marginLeft: 12 }}>상태: {statusToKo(detail.status)}</span>
+                  </div>
+
+                  <hr />
+
+                  <div>
+                     <div style={{ fontWeight: 600, marginBottom: 6 }}>문의 내용</div>
+                     <div style={{ whiteSpace: 'pre-wrap' }}>{detail.question || '-'}</div>
+                  </div>
+
+                  {(() => {
+                     // 1) 백엔드가 평탄화(answer)로 내려주는 경우 (하위호환)
+                     if (detail.answer) {
+                        return (
+                           <>
+                              <hr />
+                              <div>
+                                 <div style={{ fontWeight: 600, marginBottom: 6 }}>답변</div>
+                                 <div style={{ whiteSpace: 'pre-wrap' }}>{detail.answer}</div>
+                              </div>
+                           </>
+                        )
+                     }
+
+                     // 2) 표준: 댓글 배열 표시 (comments 또는 QnaComments)
+                     const comments = detail.comments || detail.QnaComments || []
+                     if (!Array.isArray(comments) || comments.length === 0) return null
+
+                     return (
+                        <>
+                           <hr />
+                           <div>
+                              <div style={{ fontWeight: 600, marginBottom: 6 }}>답변</div>
+                              <div style={{ display: 'grid', gap: 12 }}>
+                                 {comments
+                                    .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+                                    .map((c) => (
+                                       <div
+                                          key={c.id}
+                                          style={{
+                                             border: '1px solid #eee',
+                                             borderRadius: 8,
+                                             padding: 12,
+                                             background: '#fafafa',
+                                          }}
+                                       >
+                                          <div style={{ fontSize: 13, color: '#666', marginBottom: 6 }}>
+                                             {c.Admin?.name || '관리자'} · {c.createdAt ? new Date(c.createdAt).toLocaleString() : ''}
+                                          </div>
+                                          <div style={{ whiteSpace: 'pre-wrap' }}>{c.body}</div>
+                                       </div>
+                                    ))}
+                              </div>
+                           </div>
+                        </>
+                     )
+                  })()}
+               </div>
+            </div>
+         )}
+      </>
+   )
+}

--- a/src/pages/user/Inquiry/Create/InquiryForm.jsx
+++ b/src/pages/user/Inquiry/Create/InquiryForm.jsx
@@ -1,53 +1,76 @@
 // re-earth-frontend/src/pages/user/Inquiry/Create/InquiryForm.jsx
-import { useNavigate } from "react-router-dom";
-import "./inquiryForm.scss";
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { createQnaThunk } from '../../../../features/qnaSlice'
+import './inquiryForm.scss'
+
 function InquiryForm() {
-  const navigate = useNavigate();
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    alert("문의가 성공적으로 등록되었습니다!");
-    navigate("/user/my");
-  };
-  return (
-    <section id="main1">
-      <div className="container" id="area">
-        <form action="submit" className="inquire mt-80">
-          <h2>1:1 문의</h2>
-          <div className="inquire--header mt-80">
-            <input type="text" placeholder="제목을 입력하세요." />
-            <select name="category">
-              <option value="배송" defaultChecked>
-                배송
-              </option>
-              <option value="기부">기부</option>
-              <option value="인증/적립">인증/적립</option>
-              <option value="주문/결제">주문/결제</option>
-              <option value="서비스">서비스</option>
-              <option value="기타">기타</option>
-            </select>
-          </div>
-          <textarea
-            className="mt-40"
-            name="content"
-            placeholder="내용을 입력하세요."
-            rows={15}
-          ></textarea>
-          <div className="group mt-40">
-            <button type="button" className="btn default main2">
-              돌아가기
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmit}
-              className="btn default main1"
-            >
-              작성하기
-            </button>
-          </div>
-        </form>
-      </div>
-    </section>
-  );
+   const navigate = useNavigate()
+   const dispatch = useDispatch()
+   const { loading } = useSelector((s) => s.qna || {})
+   const [form, setForm] = useState({
+      title: '',
+      category: '배송',
+      content: '',
+   })
+
+   const onChange = (e) => {
+      const { name, value } = e.target
+      setForm((prev) => ({ ...prev, [name]: value }))
+   }
+
+   const handleSubmit = async (e) => {
+      e.preventDefault()
+      const title = form.title.trim()
+      const question = form.content.trim() // 백엔드 필드명: question
+
+      if (!title) return alert('제목을 입력하세요.')
+      if (!question) return alert('내용을 입력하세요.')
+
+      try {
+         await dispatch(createQnaThunk({ title, question })).unwrap()
+         alert('문의가 성공적으로 등록되었습니다!')
+         navigate('/user/my')
+      } catch (err) {
+         console.error(err)
+         alert(typeof err?.message === 'string' ? err.message : '문의 등록 실패')
+      }
+   }
+
+   const handleBack = () => navigate(-1)
+
+   return (
+      <section id="main1">
+         <div className="container" id="area">
+            <form className="inquire mt-80" onSubmit={handleSubmit}>
+               <h2>1:1 문의</h2>
+               <div className="inquire--header mt-80">
+                  <input type="text" name="title" placeholder="제목을 입력하세요." value={form.title} onChange={onChange} disabled={loading} />
+                  <select name="category" value={form.category} onChange={onChange} disabled={loading}>
+                     <option value="배송">배송</option>
+                     <option value="기부">기부</option>
+                     <option value="인증/적립">인증/적립</option>
+                     <option value="주문/결제">주문/결제</option>
+                     <option value="서비스">서비스</option>
+                     <option value="기타">기타</option>
+                  </select>
+               </div>
+
+               <textarea className="mt-40" name="content" placeholder="내용을 입력하세요." rows={15} value={form.content} onChange={onChange} disabled={loading} />
+
+               <div className="group mt-40">
+                  <button type="button" className="btn default main2" onClick={handleBack} disabled={loading}>
+                     돌아가기
+                  </button>
+                  <button type="submit" className="btn default main1" disabled={loading}>
+                     {loading ? '등록 중…' : '작성하기'}
+                  </button>
+               </div>
+            </form>
+         </div>
+      </section>
+   )
 }
 
-export default InquiryForm;
+export default InquiryForm


### PR DESCRIPTION
## feat(qna): InquiryContent에 내 문의 목록/상세 연동 및 모달 추가
- fetchMyQnasThunk로 목록 조회, 탭별 필터(통합/대기/완료)
- 페이지네이션 적용(PER_PAGE=10)
- 상세 모달에서 answer 또는 comments/QnaComments 타임라인 렌더링
- '새 문의작성' 탭 클릭 시 /inquiry/new 이동

## feat(admin-qna): 관리자 1:1 문의 목록/답변/상태변경 연동
- adminFetchQnaListThunk, adminAnswerQnaThunk, adminUpdateQnaStatusThunk 사용
- 행 확장 시 질문 본문/액션 버튼(답변/답변완료/종료) 노출
- 상태 필터(OPEN/ANSWERED/CLOSED) 및 페이지네이션 적용

## feat(api): qnaApi 추가 및 axios 인터셉터 개선
- /qna, /qna/me, /qna/:id, /qna/:id 삭제 함수 추가
- /auth/(login|login-admin|join) 요청은 토큰 헤더 생략

## refactor(store): qnaSlice/adminQnaSlice 등록 및 rootReducer 갱신
- rootReducer에 qna, adminQna 리듀서 추가

## fix(auth): 마이페이지 로그아웃 시 /login으로 이동
- MyPage.handleLogOut에서 confirm → logoutUserThunk → navigate('/login')

## fix(items): MainPage에서 state.items로 선택자 수정
- rootReducer 키와 slice 일치

## chore(ui): CustomerServiceContent 더미 데이터 유지 + 실제 탭만 API 연동
- 다른 서브탭은 기존 더미 유지, '1:1문의' 탭만 실연동
